### PR TITLE
Previous workspace got wrong index fix

### DIFF
--- a/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs
@@ -171,7 +171,7 @@ namespace workspacer
 
             var index = workspaces.IndexOf(currentWorkspace);
             if (index == 0)
-                index = _workspaces.Count - 1;
+                index = workspaces.Count - 1;
             else
                 index = index - 1;
 


### PR DESCRIPTION
Previous workspace looked at the wrong container, and got the wrong index, changing to the correct container, now gives the correct amount of workspaces, when looking at which index to switch to.

issue #198 