### PR TITLE
Fix description of alt-shift-/

### DIFF
--- a/src/workspacer/Keybinds/KeybindManager.cs
+++ b/src/workspacer/Keybinds/KeybindManager.cs
@@ -374,7 +374,7 @@ You can either change your custom hotkey or reassign the default hotkey";
                 () => _context.ToggleConsoleWindow(), "toggle debug console");
 
             Subscribe(mod | KeyModifiers.LShift, Keys.Oem2,
-                () => ShowKeybindDialog(), "open keybind window");
+                () => ShowKeybindDialog(), "toggle keybind window");
         }
 
         private string GetKeybindString(KeyModifiers mods, Keys keys)


### PR DESCRIPTION
This request fixes the description of keybind for alt-shift-/.
It is currently `"open keybind window"` but the actual behavior is to toggle the keybind window.

Note: this request accidentally includes unrelated change (in line 311-313) that fixes its newline code.
I could not remove this unrelated change from the commit when I made a commit with using my editor (VSCode) and code editor provided by Github website.
