### PR TITLE
Add chocolatey and scoop installation in docs

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -6,7 +6,27 @@ type: docs
 
 # installing
 
-[download the latest installer or download the latest zip file and extract to a folder somewhere.](https://github.com/rickbutton/workspacer/releases/latest) workspacer automatically checks for updates.
+workspacer is available via [Chocolatey](https://community.chocolatey.org/packages/workspacer):
+
+```
+choco install workspacer
+```
+
+and [Scoop](https://scoop.sh/):
+
+```
+scoop bucket add extras
+scoop install workspacer
+```
+
+alternatively, you can check out the prebuilt binaries [here](https://github.com/rickbutton/workspacer/releases/latest). 
+
+workspacer automatically checks for updates. however, if you are using a package manager with either Chocolatey or Scoop, you should uncomment/add this line in your workspacer config to disable autoupdates:
+
+```cs
+context.Branch = Branch.None;
+```
+
 
 # configuring
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -6,7 +6,9 @@ type: docs
 
 # installing
 
-workspacer is available via [Chocolatey](https://community.chocolatey.org/packages/workspacer):
+download the installer or the zip file from the [Releases](https://github.com/rickbutton/workspacer/releases/latest) page and install/unzip it anywhere you like. 
+
+alternatively, workspacer is available via [Chocolatey](https://community.chocolatey.org/packages/workspacer):
 
 ```
 choco install workspacer
@@ -18,8 +20,6 @@ and [Scoop](https://scoop.sh/):
 scoop bucket add extras
 scoop install workspacer
 ```
-
-alternatively, you can check out the prebuilt binaries [here](https://github.com/rickbutton/workspacer/releases/latest). 
 
 workspacer automatically checks for updates. however, if you are using a package manager with either Chocolatey or Scoop, you should uncomment/add this line in your workspacer config to disable autoupdates:
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -6,7 +6,7 @@ type: docs
 
 # installing
 
-download the installer or the zip file from the [Releases](https://github.com/rickbutton/workspacer/releases/latest) page and install/unzip it anywhere you like. 
+download the installer or the zip file from the [Releases](https://github.com/workspacer/workspacer/releases/latest) page and install/unzip it anywhere you like. 
 
 alternatively, workspacer is available via [Chocolatey](https://community.chocolatey.org/packages/workspacer):
 


### PR DESCRIPTION
workspacer is available in Scoop, and recently I have started to maintain a [Chocolatey package of workspacer](https://community.chocolatey.org/packages/workspacer). It might be good to add these installation methods to the docs.