### PR TITLE
Handles empty titles for short titles

### DIFF
--- a/src/workspacer.Bar/Widgets/TitleWidget.cs
+++ b/src/workspacer.Bar/Widgets/TitleWidget.cs
@@ -11,7 +11,7 @@ namespace workspacer.Bar.Widgets
         public Color MonitorHasFocusColor { get; set; } = Color.Yellow;
         public bool IsShortTitle { get; set; } = false;
         public string NoWindowMessage { get; set; } = "No Windows";
-       
+
 
         public override IBarWidgetPart[] GetParts()
         {
@@ -26,9 +26,10 @@ namespace workspacer.Bar.Widgets
                 {
                     return Parts(Part(window.Title, color, fontname: FontName));
                 }
-                else 
+                else
                 {
-                        string ShortTitle = window.Title.Split(new char[] { '-', '—', '|' }, StringSplitOptions.RemoveEmptyEntries).Last();
+                        var parts = window.Title.Split(new char[] { '-', '—', '|' }, StringSplitOptions.RemoveEmptyEntries);
+                        string ShortTitle = parts.Length > 0 ? parts.Last() : window.Title;
                         return Parts(Part(ShortTitle, color, fontname: FontName));
                 }
             } else

--- a/src/workspacer.Bar/Widgets/TitleWidget.cs
+++ b/src/workspacer.Bar/Widgets/TitleWidget.cs
@@ -28,11 +28,11 @@ namespace workspacer.Bar.Widgets
                 }
                 else
                 {
-                        var parts = window.Title.Split(new char[] { '-', '—', '|' }, StringSplitOptions.RemoveEmptyEntries);
-                        string ShortTitle = parts.Length > 0 ? parts.Last() : window.Title;
-                        return Parts(Part(ShortTitle, color, fontname: FontName));
+                    var shortTitle = GetShortTitle(window.Title);
+                    return Parts(Part(shortTitle, color, fontname: FontName));
                 }
-            } else
+            }
+            else
             {
                 return Parts(Part(NoWindowMessage, color, fontname: FontName));
             }
@@ -75,6 +75,16 @@ namespace workspacer.Bar.Widgets
         private void RefreshFocusedMonitor()
         {
             Context.MarkDirty();
+        }
+
+        private string GetShortTitle(string title)
+        {
+            var parts = title.Split(new char[] { '-', '—', '|' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0)
+            {
+                return title;
+            }
+            return parts.Last();
         }
     }
 }

--- a/src/workspacer.Bar/Widgets/TitleWidget.cs
+++ b/src/workspacer.Bar/Widgets/TitleWidget.cs
@@ -77,14 +77,14 @@ namespace workspacer.Bar.Widgets
             Context.MarkDirty();
         }
 
-        private string GetShortTitle(string title)
+        public static string GetShortTitle(string title)
         {
             var parts = title.Split(new char[] { '-', '—', '|' }, StringSplitOptions.RemoveEmptyEntries);
             if (parts.Length == 0)
             {
-                return title;
+                return title.Trim();
             }
-            return parts.Last();
+            return parts.Last().Trim();
         }
     }
 }

--- a/workspacer.Bar.Tests/TitleWidgetTests.cs
+++ b/workspacer.Bar.Tests/TitleWidgetTests.cs
@@ -1,0 +1,44 @@
+using System;
+using workspacer.Bar.Widgets;
+using Xunit;
+
+namespace workspacer.Bar.Tests
+{
+    public class TitleWidgetTests
+    {
+        [Fact]
+        public void GetShortTitle_SplitHyphen()
+        {
+            var s = "workspacer - Visual Studio Code";
+            Assert.Equal("Visual Studio Code", TitleWidget.GetShortTitle(s));
+        }
+
+        [Fact]
+        public void GetShortTitle_SplitEmDash()
+        {
+            var s = "workspacer — Visual Studio Code";
+            Assert.Equal("Visual Studio Code", TitleWidget.GetShortTitle(s));
+        }
+
+        [Fact]
+        public void GetShortTitle_SplitBar()
+        {
+            var s = "workspace | Visual Studio Code";
+            Assert.Equal("Visual Studio Code", TitleWidget.GetShortTitle(s));
+        }
+
+        [Fact]
+        public void GetShortTitle_NoSeparators()
+        {
+            var s = "Visual Studio Code";
+            Assert.Equal("Visual Studio Code", TitleWidget.GetShortTitle(s));
+        }
+
+        [Fact]
+        public void GetShortTitle_EmptyString()
+        {
+            var s = "";
+            Assert.Equal("", TitleWidget.GetShortTitle(s));
+        }
+    }
+}

--- a/workspacer.Bar.Tests/workspacer.Bar.Tests.csproj
+++ b/workspacer.Bar.Tests/workspacer.Bar.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0-windows</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\workspacer.Bar\workspacer.Bar.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/workspacer.sln
+++ b/workspacer.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29306.81
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer", "src\workspacer\workspacer.csproj", "{D89294E0-EB76-440E-835C-CCD1E4CF6933}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "workspacer", "src\workspacer\workspacer.csproj", "{D89294E0-EB76-440E-835C-CCD1E4CF6933}"
 	ProjectSection(ProjectDependencies) = postProject
 		{96EFD655-F7D0-4365-AE52-CC424007A3C4} = {96EFD655-F7D0-4365-AE52-CC424007A3C4}
 		{020BFFA1-E131-44DF-9B57-C1284DC80C8A} = {020BFFA1-E131-44DF-9B57-C1284DC80C8A}
@@ -12,23 +12,25 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer", "src\workspace
 		{6D6296D4-925C-47D0-A0A7-60CEB3EC656C} = {6D6296D4-925C-47D0-A0A7-60CEB3EC656C}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.Shared", "src\workspacer.Shared\workspacer.Shared.csproj", "{D13FD20B-E571-438D-B122-E24BC5A1384F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "workspacer.Shared", "src\workspacer.Shared\workspacer.Shared.csproj", "{D13FD20B-E571-438D-B122-E24BC5A1384F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.Bar", "src\workspacer.Bar\workspacer.Bar.csproj", "{A593B7C4-750D-44EE-8617-134B53C83D5D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "workspacer.Bar", "src\workspacer.Bar\workspacer.Bar.csproj", "{A593B7C4-750D-44EE-8617-134B53C83D5D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.Gap", "src\workspacer.Gap\workspacer.Gap.csproj", "{6D6296D4-925C-47D0-A0A7-60CEB3EC656C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "workspacer.Gap", "src\workspacer.Gap\workspacer.Gap.csproj", "{6D6296D4-925C-47D0-A0A7-60CEB3EC656C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.Native", "src\workspacer.Native\workspacer.Native.csproj", "{60D4AAD0-104C-4820-B141-88FCA2DA0E6C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "workspacer.Native", "src\workspacer.Native\workspacer.Native.csproj", "{60D4AAD0-104C-4820-B141-88FCA2DA0E6C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.Watcher", "src\workspacer.Watcher\workspacer.Watcher.csproj", "{020BFFA1-E131-44DF-9B57-C1284DC80C8A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "workspacer.Watcher", "src\workspacer.Watcher\workspacer.Watcher.csproj", "{020BFFA1-E131-44DF-9B57-C1284DC80C8A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.ActionMenu", "src\workspacer.ActionMenu\workspacer.ActionMenu.csproj", "{96EFD655-F7D0-4365-AE52-CC424007A3C4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "workspacer.ActionMenu", "src\workspacer.ActionMenu\workspacer.ActionMenu.csproj", "{96EFD655-F7D0-4365-AE52-CC424007A3C4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.FocusIndicator", "src\workspacer.FocusIndicator\workspacer.FocusIndicator.csproj", "{E7F2E1A7-2771-4924-A8D8-20761188D6F4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "workspacer.FocusIndicator", "src\workspacer.FocusIndicator\workspacer.FocusIndicator.csproj", "{E7F2E1A7-2771-4924-A8D8-20761188D6F4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.Shared.Tests", "src\workspacer.Shared.Tests\workspacer.Shared.Tests.csproj", "{C69C243C-E40C-46CC-8599-DC7CC39F4C6F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "workspacer.Shared.Tests", "src\workspacer.Shared.Tests\workspacer.Shared.Tests.csproj", "{C69C243C-E40C-46CC-8599-DC7CC39F4C6F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.Tests", "src\workspacer.Tests\workspacer.Tests.csproj", "{36884A7D-B921-4F6D-A324-239D79AF38F2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "workspacer.Tests", "src\workspacer.Tests\workspacer.Tests.csproj", "{36884A7D-B921-4F6D-A324-239D79AF38F2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.Bar.Tests", "workspacer.Bar.Tests\workspacer.Bar.Tests.csproj", "{9C7EB6A7-F376-4028-BA7D-E424F56591FF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -160,6 +162,18 @@ Global
 		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Release|x64.Build.0 = Release|Any CPU
 		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Release|x86.ActiveCfg = Release|Any CPU
 		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Release|x86.Build.0 = Release|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Debug|x64.Build.0 = Debug|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Debug|x86.Build.0 = Debug|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Release|x64.ActiveCfg = Release|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Release|x64.Build.0 = Release|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Release|x86.ActiveCfg = Release|Any CPU
+		{9C7EB6A7-F376-4028-BA7D-E424F56591FF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
**Current behaviour:** `Last` raises `InvalidOperationException` when the `Enumerable` has length of 0.

**Fixed behaviour:** `Last` is only called when `parts` has a length > 0.