### PR TITLE
Reverted to AllocConsole method for focus

### DIFF
--- a/src/workspacer.Native/Native/FocusStealer.cs
+++ b/src/workspacer.Native/Native/FocusStealer.cs
@@ -16,8 +16,11 @@ namespace workspacer
 
         public static void Steal(IntPtr windowToFocus)
         {
-            Win32.keybd_event(0, 0, 0, UIntPtr.Zero);
-
+            Win32.AllocConsole();
+            var hWndConsole = Win32.GetConsoleWindow();
+            Win32.SetWindowPos(hWndConsole, IntPtr.Zero, 0, 0, 0, 0, Win32.SetWindowPosFlags.IgnoreZOrder);
+            Win32.FreeConsole();
+            
             Win32.SetForegroundWindow(windowToFocus);
         }
     }

--- a/src/workspacer.Native/Native/Win32/Win32.Window.cs
+++ b/src/workspacer.Native/Native/Win32/Win32.Window.cs
@@ -222,9 +222,6 @@ namespace workspacer
 		public static extern bool SetForegroundWindow(IntPtr hWnd);
 
         [DllImport("user32.dll")]
-        public static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
-
-        [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool AllowSetForegroundWindow(int processId);
 


### PR DESCRIPTION
See #110, I'm having this exact problem using the Win key, the start menu appears when I switch workspaces with Win + {1..9} (which is annoying of course). Not sure why @rickbutton made this change when this was working properly.