### PR TITLE
Improve GitHub Actions & Make release files consistent

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Prerelease
       uses: softprops/action-gh-release@v1
       with:
-        name: workspacer v${{ env.VERSION }}
+        name: workspacer ${{ env.VERSION }}
         tag_name: v${{ env.VERSION }}
         prerelease: true
         files: |

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -6,44 +6,50 @@ on:
       - "beta"
 
 jobs:
-  build-and-release-beta:
+  build-and-release:
     runs-on: windows-latest
 
     steps:
+    # Build
     - uses: actions/checkout@v2
-    # NOTE: github.run_number increments for each run of the workflow. Therefore, you can have v0.9.11-beta.1 followed by v0.9.12-beta.2
-    - run: Write-Output VERSION="$(([Xml] (Get-Content .\src\workspacer\workspacer.csproj)).Project.PropertyGroup.Version)-beta.$(${{ github.run_number }})" >> $env:GITHUB_ENV
+    - name: Get version
+      # NOTE: github.run_number increments for each run of the workflow. Therefore, you can have v0.9.11-beta.1 followed by v0.9.12-beta.2
+      run: Write-Output VERSION="$(([Xml] (Get-Content .\src\workspacer\workspacer.csproj)).Project.PropertyGroup.Version)-beta.${{ github.run_number }}" >> $env:GITHUB_ENV
     - name: Restore solution
       run: dotnet restore
-    - name: Build
-      run: dotnet publish /p:DefineConstants=BRANCH_beta /p:Version=$env:VERSION --configuration Release --no-restore
+    - name: Build project
+      run: dotnet publish /p:DefineConstants=BRANCH_beta --configuration Release --no-restore
     - uses: actions/upload-artifact@v2
       with:
-        name: workspacer-build
+        name: Build
         path: .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\
-    - name: Publish installer
+    - name: Build installer
       run: |
-        Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-        scoop install wixtoolset
+        $env:PATH += ";${env:WIX}bin" # Add to PATH
         .\scripts\buildinstaller.ps1 -buildDir .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\ -version $env:VERSION
     - uses: actions/upload-artifact@v2
       with:
-        name: workspacer-installer
+        name: Setup
         path: .\out\workspacer-${{ env.VERSION }}.msi
+    
+    # Release
     - name: Zip build output
       run: Compress-Archive -Path .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\* -DestinationPath ".\out\workspacer-$env:VERSION.zip"
-    - uses: dev-drprasad/delete-tag-and-release@v0.1.2
+    - name: Delete temp beta tag
+      uses: dev-drprasad/delete-tag-and-release@v0.1.2
       with:
        delete_release: true
        tag_name: beta
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - uses: marvinpinto/action-automatic-releases@latest
+    - name: Release
+      uses: softprops/action-gh-release@v1
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        automatic_release_tag: ${{ env.VERSION }}
-        title: workspacer ${{ env.VERSION }}
+        name: workspacer v${{ env.VERSION }}
+        tag_name: v${{ env.VERSION }}
         prerelease: true
         files: |
-          out/workspacer-${{ env.VERSION }}.zip
-          out/workspacer-${{ env.VERSION }}.msi
+          ./out/workspacer-${{ env.VERSION }}.zip
+          ./out/workspacer-${{ env.VERSION }}.msi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -6,7 +6,7 @@ on:
       - "beta"
 
 jobs:
-  build-and-release:
+  build-and-prerelease:
     runs-on: windows-latest
 
     steps:
@@ -42,7 +42,7 @@ jobs:
        tag_name: beta
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Release
+    - name: Prerelease
       uses: softprops/action-gh-release@v1
       with:
         name: workspacer v${{ env.VERSION }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -10,57 +10,37 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    # Build
     - uses: actions/checkout@v2
-    - run: Write-Output VERSION="$(([Xml] (Get-Content .\src\workspacer\workspacer.csproj)).Project.PropertyGroup.Version)" >> $env:GITHUB_ENV
+    - name: Get version
+      run: Write-Output VERSION="$(([Xml] (Get-Content .\src\workspacer\workspacer.csproj)).Project.PropertyGroup.Version)" >> $env:GITHUB_ENV
     - name: Restore solution
       run: dotnet restore
-    - name: Build
+    - name: Build project
       run: dotnet publish /p:DefineConstants=BRANCH_stable --configuration Release --no-restore
     - uses: actions/upload-artifact@v2
       with:
-        name: workspacer-build
+        name: Build
         path: .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\
-    - name: Publish installer
+    - name: Build installer
       run: |
-        Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-        scoop install wixtoolset
-        .\scripts\buildinstaller.ps1 -buildDir .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\ -version "stable-$env:VERSION"
+        $env:PATH += ";${env:WIX}bin" # Add to PATH
+        .\scripts\buildinstaller.ps1 -buildDir .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\ -version "$env:VERSION-stable"
     - uses: actions/upload-artifact@v2
       with:
-        name: workspacer-setup
-        path: .\out\workspacer-stable-${{ env.VERSION }}.msi
+        name: Setup
+        path: .\out\workspacer-${{ env.VERSION }}-stable.msi
+    
+    # Release
     - name: Zip build output
-      run: Compress-Archive -Path .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\* -DestinationPath ".\out\workspacer-stable-$env:VERSION.zip"
-    - uses: dev-drprasad/delete-tag-and-release@v0.1.2
+      run: Compress-Archive -Path .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\* -DestinationPath ".\out\workspacer-$env:VERSION-stable.zip"
+    - name: Release
+      uses: softprops/action-gh-release@v1
       with:
-       delete_release: true
-       tag_name: ${{ github.ref }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: workspacer ${{ env.VERSION }}
+        name: workspacer ${{ env.VERSION }}
         body: https://www.workspacer.org/changelog
-    - name: Upload .zip
-      uses: actions/upload-release-asset@v1
+        files: |
+          ./out/workspacer-${{ env.VERSION }}-stable.zip
+          ./out/workspacer-${{ env.VERSION }}-stable.msi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./out/workspacer-stable-${{ env.VERSION }}.zip
-        asset_name: workspacer-stable-${{ env.VERSION }}.zip
-        asset_content_type: application/zip
-    - name: Upload .msi
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./out/workspacer-stable-${{ env.VERSION }}.msi
-        asset_name: workspacer-stable-${{ env.VERSION }}.msi
-        asset_content_type: application/x-msdownload

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,3 +1,4 @@
+
 name: unstable
 
 on:
@@ -5,46 +6,52 @@ on:
     branches: [ master ]
 
 jobs:
-  build-and-prerelease:
+  build-and-release:
     runs-on: windows-latest
 
     steps:
+    # Build
     - uses: actions/checkout@v2
-    - run: Write-Output VERSION="$(([Xml] (Get-Content .\src\workspacer\workspacer.csproj)).Project.PropertyGroup.Version).$(${{ github.run_number }})" >> $env:GITHUB_ENV
+    - name: Get version
+      run: Write-Output VERSION="$(([Xml] (Get-Content .\src\workspacer\workspacer.csproj)).Project.PropertyGroup.Version).$(${{ github.run_number }})" >> $env:GITHUB_ENV
     - name: Restore solution
       run: dotnet restore
-    - name: Build
-      run: dotnet publish /p:DefineConstants=BRANCH_unstable /p:Version=$env:VERSION --configuration Release --no-restore
+    - name: Build project
+      run: dotnet publish /p:DefineConstants=BRANCH_unstable --configuration Release --no-restore
     - uses: actions/upload-artifact@v2
       with:
-        name: workspacer-build
+        name: Build
         path: .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\
-    - name: Publish installer
+    - name: Build installer
       run: |
-        Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-        scoop install wixtoolset
-        .\scripts\buildinstaller.ps1 -buildDir .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\ -version "unstable-latest"
+        $env:PATH += ";${env:WIX}bin" # Add to PATH
+        .\scripts\buildinstaller.ps1 -buildDir .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\ -version "latest-unstable"
     - uses: actions/upload-artifact@v2
       with:
-        name: workspacer-installer
-        path: .\out\workspacer-unstable-latest.msi
+        name: Setup
+        path: .\out\workspacer-latest-unstable.msi
+    
+    # Release
     - name: Zip build output
-      run: Compress-Archive -Path .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\* -DestinationPath ".\out\workspacer-unstable-latest.zip"
-    - uses: dev-drprasad/delete-tag-and-release@v0.1.2
+      run: Compress-Archive -Path .\src\workspacer\bin\Release\net5.0-windows\win10-x64\publish\* -DestinationPath ".\out\workspacer-latest-unstable.zip"
+    - name: Delete existing unstable tag and release
+      uses: dev-drprasad/delete-tag-and-release@v0.1.2
       with:
        delete_release: true
        tag_name: unstable
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - uses: marvinpinto/action-automatic-releases@latest
+    - name: Prerelease
+      uses: marvinpinto/action-automatic-releases@latest
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         automatic_release_tag: unstable
         title: workspacer ${{ env.VERSION }}
         prerelease: true
         files: |
-          out/workspacer-unstable-latest.zip
-          out/workspacer-unstable-latest.msi
+          out/workspacer-latest-unstable.zip
+          out/workspacer-latest-unstable.msi
+
   deploy-site:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,4 +1,3 @@
-
 name: unstable
 
 on:
@@ -6,7 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build-and-release:
+  build-and-prerelease:
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
- Replaced the archived [create-release](https://github.com/actions/create-release) and [upload-release-asset](https://github.com/actions/upload-release-asset) with new maintained action listed there.
- Add names to some steps and some comments
- Removed the scoop installation as WiX Toolset is already preinstalled in the GitHub runner as it turns out.
- Fixed the beta tag naming (no `v` on the start)

Also made the release file names consistent with the beta naming (example):
- beta: `workspacer-v0.9.11-beta.1.zip`
- stable: `workspacer-v0.9.11-stable.zip`
- unstable: `workspacer-latest-unstable.zip`

Workflow tested [here](https://github.com/sitiom/workspacer).