### PR TITLE
Added function to print logging info for active window

### DIFF
--- a/src/workspacer.Native/Native/WindowsManager.cs
+++ b/src/workspacer.Native/Native/WindowsManager.cs
@@ -91,15 +91,14 @@ namespace workspacer
 
         public void DumpWindowDebugOutputForFocusedWindow()
         {
-            var output = "";
             var focusedWindow = Windows.Where(win => win.IsFocused)
                 .Select(win => win).FirstOrDefault();
 
             if (focusedWindow != null)
             {
-                output += GenerateWindowDebugOutput(focusedWindow) + "\r\n\r\n";
+                var output = GenerateWindowDebugOutput(focusedWindow);
+                OpenDebugOutput(output);
             }
-            OpenDebugOutput(output);
         }
 
         public void DumpWindowUnderCursorDebugOutput()

--- a/src/workspacer.Native/Native/WindowsManager.cs
+++ b/src/workspacer.Native/Native/WindowsManager.cs
@@ -89,6 +89,19 @@ namespace workspacer
             OpenDebugOutput(output);
         }
 
+        public void DumpWindowDebugOutputForFocusedWindow()
+        {
+            var output = "";
+            var focusedWindow = Windows.Where(win => win.IsFocused)
+                .Select(win => win).FirstOrDefault();
+
+            if (focusedWindow != null)
+            {
+                output += GenerateWindowDebugOutput(focusedWindow) + "\r\n\r\n";
+            }
+            OpenDebugOutput(output);
+        }
+
         public void DumpWindowUnderCursorDebugOutput()
         {
             var location = Control.MousePosition;
@@ -196,7 +209,7 @@ namespace workspacer
         {
             return idChild == Win32.CHILDID_SELF && idObject == Win32.OBJID.OBJID_WINDOW && hwnd != IntPtr.Zero;
         }
-        
+
         private void RegisterWindow(IntPtr handle, bool emitEvent = true)
         {
             if (!_windows.ContainsKey(handle))

--- a/src/workspacer.Shared/Window/IWindowsManager.cs
+++ b/src/workspacer.Shared/Window/IWindowsManager.cs
@@ -12,6 +12,7 @@ namespace workspacer
     {
         IWindowsDeferPosHandle DeferWindowsPos(int count);
         void DumpWindowDebugOutput();
+        void DumpWindowDebugOutputForFocusedWindow();
         void DumpWindowUnderCursorDebugOutput();
 
         event WindowFocusDelegate WindowFocused;


### PR DESCRIPTION
Workspacer is already keyboard oriented, this should be a nice addition
for anyone who wants to use just keyboard.

I found myself wanting this feature while setting up routes, and getting annoyed by using the mouse.
Also getting annoyed by having to scroll up through the entire list of windows.