### PR TITLE
chore: rearrange tray menu item

### DIFF
--- a/src/workspacer/Workspacer.cs
+++ b/src/workspacer/Workspacer.cs
@@ -39,10 +39,10 @@ namespace workspacer
             });
 
             // init system tray
-            _context.SystemTray.AddToContextMenu("enable/disable workspacer", () => _context.Enabled = !_context.Enabled);
-            _context.SystemTray.AddToContextMenu("quit workspacer", () => _context.Quit());
-            _context.SystemTray.AddToContextMenu("restart workspacer", () => _context.Restart());
-            _context.SystemTray.AddToContextMenu("show/hide keybind help", () => _context.Keybinds.ShowKeybindDialog());
+            _context.SystemTray.AddToContextMenu("Show/Hide Keybinddings help", () => _context.Keybinds.ShowKeybindDialog());
+            _context.SystemTray.AddToContextMenu("Enable/Disable workspacer", () => _context.Enabled = !_context.Enabled);
+            _context.SystemTray.AddToContextMenu("Restart workspacer", () => _context.Restart());
+            _context.SystemTray.AddToContextMenu("Quit workspacer", () => _context.Quit());
             if (ConfigHelper.CanCreateExampleConfig())
             {
                 _context.SystemTray.AddToContextMenu("create example workspacer.config.csx", CreateExampleConfig);


### PR DESCRIPTION
It is commonly expected that the `Quit` menu item is the last one in the list and `Restart` should probably be directly above `Quit`