### PR TITLE
Fix #308 - docs build error

### DIFF
--- a/docs/themes/workspacer/layouts/partials/footer.html
+++ b/docs/themes/workspacer/layouts/partials/footer.html
@@ -2,7 +2,7 @@
 	<p>&copy; Licence MIT.</p>
 	<nav class="nav-footer">
 		{{ range .Site.Menus.footer }}
-			<a href="{{ .URL }}">{{ .Name }}</a>
+			<a href="{{ .Params.URL }}">{{ .Name }}</a>
 		{{ end }}
 	</nav>
 </footer>

--- a/docs/themes/workspacer/layouts/partials/header.html
+++ b/docs/themes/workspacer/layouts/partials/header.html
@@ -5,15 +5,15 @@
 	<nav class="nav-dekstop nav-main">
 		{{ $currentPage := . }}
 		{{ range .Site.Menus.main }}
-			{{ $active := or (eq $.URL .URL) (or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .)) }}
-			<a href="{{ .URL }}">{{ .Name }}</a>
+			{{ $active := or (eq $.Params.URL .Params.URL) (or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .)) }}
+			<a href="{{ .Params.URL }}">{{ .Name }}</a>
 		{{end}}
 	</nav>
 	<nav class="nav-dekstop nav-extra">
 		{{ $currentPage := . }}
 		{{ range .Site.Menus.extra }}
-			{{ $active := or (eq $.URL .URL) (or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .)) }}
-			<a href="{{ .URL }}" class="btn btn-small btn-light">{{ .Name }}</a>
+			{{ $active := or (eq $.Params.URL .Params.URL) (or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .)) }}
+			<a href="{{ .Params.URL }}" class="btn btn-small btn-light">{{ .Name }}</a>
 		{{end}}
 	</nav>
 	<button class="nav-phone-toggle btn btn-light">{{ partial "icons/menu.svg" . }}</button>
@@ -21,14 +21,14 @@
 		{{ partial "window-decorations" . }}
 		{{ $currentPage := . }}
 		{{ range .Site.Menus.main }}
-			{{ $active := or (eq $.URL .URL) (or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .)) }}
-			<a href="{{ .URL }}" class="btn btn-small btn-light">{{ .Name }}</a>
+			{{ $active := or (eq $.Params.URL .Params.URL) (or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .)) }}
+			<a href="{{ .Params.URL }}" class="btn btn-small btn-light">{{ .Name }}</a>
 		{{end}}
 		<div class="extra-separator"></div>
 		{{ $currentPage := . }}
 		{{ range .Site.Menus.extra }}
-			{{ $active := or (eq $.URL .URL) (or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .)) }}
-			<a href="{{ .URL }}" class="btn btn-small">{{ .Name }}</a>
+			{{ $active := or (eq $.Params.URL .Params.URL) (or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .)) }}
+			<a href="{{ .Params.URL }}" class="btn btn-small">{{ .Name }}</a>
 		{{end}}
 	</nav>
 </header>


### PR DESCRIPTION
This should fix #308.
As mentioned [here](https://discourse.gohugo.io/t/pages-url-is-deprecated/20645), the Page.URL variable in Hugo was deprecated and got removed so I changed everywhere it appeared to `.Params.URL`.