### PR TITLE
New unstable is 0.9.12 now.

### DIFF
--- a/src/workspacer.ActionMenu/workspacer.ActionMenu.csproj
+++ b/src/workspacer.ActionMenu/workspacer.ActionMenu.csproj
@@ -7,6 +7,6 @@
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <Description>a tiling window manager for Windows</Description>
     <Authors>Rick Button</Authors>
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
   </PropertyGroup>
 </Project>

--- a/src/workspacer.Bar/workspacer.Bar.csproj
+++ b/src/workspacer.Bar/workspacer.Bar.csproj
@@ -7,6 +7,6 @@
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <Description>a tiling window manager for Windows</Description>
     <Authors>Rick Button</Authors>
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
   </PropertyGroup>
 </Project>

--- a/src/workspacer.FocusIndicator/workspacer.FocusIndicator.csproj
+++ b/src/workspacer.FocusIndicator/workspacer.FocusIndicator.csproj
@@ -7,6 +7,6 @@
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <Description>a tiling window manager for Windows</Description>
     <Authors>Rick Button</Authors>
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
   </PropertyGroup>
 </Project>

--- a/src/workspacer.Gap/workspacer.Gap.csproj
+++ b/src/workspacer.Gap/workspacer.Gap.csproj
@@ -7,6 +7,6 @@
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <Description>a tiling window manager for Windows</Description>
     <Authors>Rick Button</Authors>
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
   </PropertyGroup>
 </Project>

--- a/src/workspacer.Native/workspacer.Native.csproj
+++ b/src/workspacer.Native/workspacer.Native.csproj
@@ -7,7 +7,7 @@
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <Description>a tiling window manager for Windows</Description>
     <Authors>Rick Button</Authors>
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.InteropServices.WindowsRuntime" Version="4.3.0" />

--- a/src/workspacer.Setup/Product.wxs
+++ b/src/workspacer.Setup/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="workspacer" Language="1033" Version="0.9.11" Manufacturer="Rick Button" UpgradeCode="c153340a-624e-40fc-bfc3-4cb29ca7f267">
+  <Product Id="*" Name="workspacer" Language="1033" Version="0.9.12" Manufacturer="Rick Button" UpgradeCode="c153340a-624e-40fc-bfc3-4cb29ca7f267">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" Platform="x64" />
 
     <Upgrade Id="c153340a-624e-40fc-bfc3-4cb29ca7f267" />

--- a/src/workspacer.Shared.Tests/workspacer.Shared.Tests.csproj
+++ b/src/workspacer.Shared.Tests/workspacer.Shared.Tests.csproj
@@ -17,6 +17,6 @@
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
   </PropertyGroup>
 </Project>

--- a/src/workspacer.Shared/workspacer.Shared.csproj
+++ b/src/workspacer.Shared/workspacer.Shared.csproj
@@ -5,7 +5,7 @@
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <Description>a tiling window manager for Windows</Description>
     <Authors>Rick Button</Authors>
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="5.0.1" />

--- a/src/workspacer.TitleBar/workspacer.TitleBar.csproj
+++ b/src/workspacer.TitleBar/workspacer.TitleBar.csproj
@@ -8,6 +8,6 @@
 		<RuntimeIdentifier>win10-x64</RuntimeIdentifier>
 		<Description>a tiling window manager for Windows</Description>
 		<Authors>Rick Button</Authors>
-		<Version>0.9.11</Version>
+		<Version>0.9.12</Version>
 	</PropertyGroup>
 </Project>

--- a/src/workspacer.Watcher/workspacer.Watcher.csproj
+++ b/src/workspacer.Watcher/workspacer.Watcher.csproj
@@ -5,7 +5,7 @@
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <Description>a tiling window manager for Windows</Description>
     <Authors>Rick Button</Authors>
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/workspacer/workspacer.csproj
+++ b/src/workspacer/workspacer.csproj
@@ -7,7 +7,7 @@
     <ApplicationIcon>logo.ico</ApplicationIcon>
     <Description>a tiling window manager for Windows</Description>
     <Authors>Rick Button</Authors>
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Config\workspacer.config.template.csx" />


### PR DESCRIPTION
I made a 0.9.11 stable release in response to the Newtonsoft.Jon vulnerability (old stable had vulnerable version).

As such, we need to bump the version for the unstable version :smile: 