### PR TITLE
fix OverflowException on Win11 x64

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,11 @@
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
-            "problemMatcher": "$msCompile"
-        },
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
     ]
 }

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -131,6 +131,8 @@ public interface IBarWidgetPart
 Widgets support custom on-click functions and callbacks through the `PartClicked` Action. Icon fonts are also supported and can be set for individual widgets but require system wide installation of the font and there may be issues with `.OTF` files, so `TTF`s are recommended. To add icons to a widget you must use its unicode value.
 For example if you wanted to add this [monitor icon from FontAwesome](https://fontawesome.com/v5.15/icons/desktop?style=solid) you would have to write `"\uf108"`.
 
+Starting another process in the funcion `PartClicked` requires elevated privileges on Windows 11.
+
 #### Menu Bar Widgets
 
 - `ActiveLayoutWidget`

--- a/src/workspacer.Watcher/ConsoleHelper.cs
+++ b/src/workspacer.Watcher/ConsoleHelper.cs
@@ -27,6 +27,9 @@ namespace workspacer
                 if (handle != IntPtr.Zero)
                 {
                     var style = Win32.GetWindowLongPtr(handle, Win32.GWL_STYLE);
+                    if (Environment.Is64BitProcess) {
+                        return ((UInt64)style & (UInt64)Win32.WS.WS_VISIBLE) != 0;
+                    }
                     return ((uint)style & (uint)Win32.WS.WS_VISIBLE) != 0;
                 }
                 return false;


### PR DESCRIPTION
Fix the exception when running on Windows 11 x64:
Unhandled exception. System.OverflowException: Arithmetic operation resulted in an overflow.
   at System.IntPtr.op_Explicit(IntPtr value)
   at workspacer.ConsoleHelper.get_IsConsoleShowing() in D:\a\workspacer\workspacer\src\workspacer.Watcher\ConsoleHelper.cs:line 35
   at workspacer.ConsoleHelper.set_IsConsoleShowing(Boolean value) in D:\a\workspacer\workspacer\src\workspacer.Watcher\ConsoleHelper.cs:line 46
   at workspacer.ConsoleHelper.Initialize() in D:\a\workspacer\workspacer\src\workspacer.Watcher\ConsoleHelper.cs:line 25
   at workspacer.Watcher.Program.Main(String[] args) in D:\a\workspacer\workspacer\src\workspacer.Watcher\Program.cs:line 19