### PR TITLE
No message by Display Settings triggered restart

### DIFF
--- a/src/workspacer/ConfigContext.cs
+++ b/src/workspacer/ConfigContext.cs
@@ -228,8 +228,7 @@ namespace workspacer
             SaveState();
             var response = new LauncherResponse()
             {
-                Action = LauncherAction.RestartWithMessage,
-                Message = "A display settings change has been detected, which has automatically disabled workspacer. Press 'restart' when ready.",
+                Action = LauncherAction.Restart
             };
             SendResponse(response);
 


### PR DESCRIPTION
Removes the message and dialog box for when workspacer gets restarted due to changes in Display Settings (connecting and disconnecting monitors, going into exclusive fullscreen with non-native resolutions, changing display resolution, etc..). 

Current message is redundant since I see no reason to quit workspacer because of those reasons, user usually wants to have workspacer back ASAP, and that dialog delays this process.