### PR TITLE
Add WorkerW rule to prevent ghost notification

### DIFF
--- a/src/workspacer.Shared/Workspace/WindowRouter.cs
+++ b/src/workspacer.Shared/Workspace/WindowRouter.cs
@@ -32,6 +32,8 @@ namespace workspacer
             IgnoreProcessName("search");     // Windows 11 RTM search
             IgnoreWindowClass("Shell_TrayWnd"); // Windows 11 start
             IgnoreProcessName("ScreenClippingHost");
+            IgnoreWindowClass("WorkerW"); //Windows desktop
+
             _filters.Add((window) => !(window.ProcessId == Process.GetCurrentProcess().Id));
         }
 


### PR DESCRIPTION
Fixes ghost notification when clicking on the desktop/top bar. Fixes issue #38 and maybe #263.