### PR TITLE
Focus border improvements for full screen and dragging, as well as better fullscreen detection and support.

### DIFF
--- a/src/workspacer.FocusBorder/FocusBorderPlugin.cs
+++ b/src/workspacer.FocusBorder/FocusBorderPlugin.cs
@@ -6,7 +6,7 @@ namespace workspacer.FocusBorder
     {
         private IConfigContext _context;
         private FocusBorderPluginConfig _config;
-        private FocusBorderForm _form;
+        private IFormProxy<FocusBorderForm> _form;
 
         public FocusBorderPlugin(FocusBorderPluginConfig config)
         {
@@ -16,14 +16,19 @@ namespace workspacer.FocusBorder
         public void AfterConfig(IConfigContext context)
         {
             this._context = context;
-            this._form = new FocusBorderForm(this._config);
-            this._form.Show();
+            
+            var form = new FocusBorderForm(this._config);
+            this._form = form;
+            
+            form.Show();
             
             // Update the focus border when one of the workspaces updated its layout.
             foreach (var workspace in context.WorkspaceContainer.GetAllWorkspaces())
             {
                 workspace.OnLayoutCompleted += OnLayoutCompleted;
             }
+
+            ((WindowsManager) context.Windows).WindowUpdated += WindowUpdated;
             
             _context.Workspaces.FocusedMonitorUpdated += RefreshFocusedMonitor;
 
@@ -32,7 +37,7 @@ namespace workspacer.FocusBorder
                 context.Workspaces.FocusedWorkspace.ManagedWindows.FirstOrDefault(x => x.IsFocused);
             initial ??= context.Workspaces.FocusedWorkspace.ManagedWindows.FirstOrDefault();
             if (initial is not null)
-                this._form.SetWindow(initial);
+                form.SetWindow(initial);
         }
 
         private void OnLayoutCompleted(IWorkspace workspace)
@@ -44,14 +49,22 @@ namespace workspacer.FocusBorder
             // If there is no focused window, hide the border,
             if (workspace.FocusedWindow is not null)
             {
-                if (!this._form.Visible)
-                    this._form.Show();
+                if (!this._form.Read.Visible)
+                    this._form.Execute(x => x.Show());
                 if (workspace.FocusedWindow.CanLayout)
-                    this._form.SetWindow(workspace.FocusedWindow);
+                    this._form.Execute(x => x.SetWindow(workspace.FocusedWindow));
             }
             else
             {
-                this._form.Hide();
+                this._form.Execute(x => x.Hide());
+            }
+        }
+
+        private void WindowUpdated(IWindow window, WindowUpdateType type)
+        {
+            if (type == WindowUpdateType.MinimizeStart && this._form.Read.Current == window)
+            {
+                this._form.Execute(x => x.Hide());
             }
         }
 

--- a/src/workspacer.FocusBorder/FocusBorderPlugin.cs
+++ b/src/workspacer.FocusBorder/FocusBorderPlugin.cs
@@ -46,17 +46,20 @@ namespace workspacer.FocusBorder
             if (_context.Workspaces.FocusedWorkspace != workspace)
                 return;
 
-            // If there is no focused window, hide the border,
-            if (workspace.FocusedWindow is not null)
+            var focussed = workspace.FocusedWindow ?? workspace.LastFocusedWindow;
+            // If there is no focused window, hide the border.
+            // Disable border on moving windows for performance.
+            if (focussed is not null && !focussed.IsMouseMoving)
             {
+                if (focussed.CanLayout)
+                    this._form.Execute(x => x.SetWindow(focussed));
                 if (!this._form.Read.Visible)
                     this._form.Execute(x => x.Show());
-                if (workspace.FocusedWindow.CanLayout)
-                    this._form.Execute(x => x.SetWindow(workspace.FocusedWindow));
             }
             else
             {
-                this._form.Execute(x => x.Hide());
+                if (this._form.Read.Visible)
+                    this._form.Execute(x => x.Hide());
             }
         }
 

--- a/src/workspacer.FocusBorder/IFormProxy.cs
+++ b/src/workspacer.FocusBorder/IFormProxy.cs
@@ -2,17 +2,17 @@
 
 namespace workspacer.FocusBorder
 {
-    public interface IFormProxy<Form>
+    public interface IFormProxy<TForm>
     {
         /// <summary>
         /// Execute the given action in the thread that owns the form.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        public void Execute(Action<Form> action);
+        void Execute(Action<TForm> action);
 
         /// <summary>
         /// Get the underlying form. This property should only be used to read values.
         /// </summary>
-        public Form Read { get; }
+        TForm Read { get; }
     }
 }

--- a/src/workspacer.FocusBorder/IFormProxy.cs
+++ b/src/workspacer.FocusBorder/IFormProxy.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace workspacer.FocusBorder
+{
+    public interface IFormProxy<Form>
+    {
+        /// <summary>
+        /// Execute the given action in the thread that owns the form.
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        public void Execute(Action<Form> action);
+
+        /// <summary>
+        /// Get the underlying form. This property should only be used to read values.
+        /// </summary>
+        public Form Read { get; }
+    }
+}

--- a/src/workspacer.Native/Native/WindowsManager.cs
+++ b/src/workspacer.Native/Native/WindowsManager.cs
@@ -315,13 +315,9 @@ namespace workspacer
 
         private void WindowMove(IntPtr handle)
         {
-            if (_mouseMoveWindow != null && _windows.ContainsKey(handle))
+            if (_windows.ContainsKey(handle) && _windows[handle].CanLayout)
             {
-                var window = _windows[handle];
-                if (_mouseMoveWindow == window)
-                {
-                    WindowUpdated?.Invoke(window, WindowUpdateType.Move);
-                }
+                WindowUpdated?.Invoke(_windows[handle], WindowUpdateType.Move);
             }
         }
 

--- a/src/workspacer.Native/Native/WindowsWindow.cs
+++ b/src/workspacer.Native/Native/WindowsWindow.cs
@@ -151,6 +151,10 @@ namespace workspacer
         public bool IsFocused => Win32.GetForegroundWindow() == _handle;
         public bool IsMinimized => Win32.IsIconic(_handle);
         public bool IsMaximized => Win32.IsZoomed(_handle);
+        public bool IsFullscreen =>
+            (~Win32.GetWindowStyleLongPtr(_handle))
+                .HasFlag(Win32.WS.WS_OVERLAPPED | Win32.WS.WS_BORDER | Win32.WS.WS_THICKFRAME);
+        
         public bool IsMouseMoving { get; internal set; }
 
         public void Focus()

--- a/src/workspacer.Native/Native/WindowsWindow.cs
+++ b/src/workspacer.Native/Native/WindowsWindow.cs
@@ -151,10 +151,17 @@ namespace workspacer
         public bool IsFocused => Win32.GetForegroundWindow() == _handle;
         public bool IsMinimized => Win32.IsIconic(_handle);
         public bool IsMaximized => Win32.IsZoomed(_handle);
-        public bool IsFullscreen =>
-            (~Win32.GetWindowStyleLongPtr(_handle))
-                .HasFlag(Win32.WS.WS_OVERLAPPED | Win32.WS.WS_BORDER | Win32.WS.WS_THICKFRAME);
-        
+
+        public bool IsFullscreen
+        {
+            get
+            {
+                var windowed = Win32.WS.WS_OVERLAPPED | Win32.WS.WS_BORDER | Win32.WS.WS_THICKFRAME;
+                // Verify none of the windowed flags are set.
+                return (Win32.GetWindowStyleLongPtr(_handle) & windowed) == 0;
+            }
+        }
+
         public bool IsMouseMoving { get; internal set; }
 
         public void Focus()

--- a/src/workspacer.Shared/Window/IWindow.cs
+++ b/src/workspacer.Shared/Window/IWindow.cs
@@ -36,6 +36,7 @@ namespace workspacer
         bool IsFocused { get; }
         bool IsMinimized { get; }
         bool IsMaximized { get; }
+        bool IsFullscreen { get; }
         bool IsMouseMoving { get; }
 
         void Focus();

--- a/src/workspacer.Shared/Workspace/Workspace.cs
+++ b/src/workspacer.Shared/Workspace/Workspace.cs
@@ -368,6 +368,13 @@ namespace workspacer
 
         public void DoLayout()
         {
+            // Skip layout if the focussed window is fullscreen.
+            if (FocusedWindow?.IsFullscreen ?? false)
+            {
+                OnLayoutCompleted?.Invoke(this);
+                return;
+            }
+
             var windows = ManagedWindows.ToList();
             if (_context.Enabled)
             {

--- a/src/workspacer.Shared/Workspace/Workspace.cs
+++ b/src/workspacer.Shared/Workspace/Workspace.cs
@@ -396,7 +396,7 @@ namespace workspacer
                             var adjustedLoc = new WindowLocation(loc.X + monitor.X, loc.Y + monitor.Y,
                                 loc.Width, loc.Height, loc.State);
 
-                            if (!window.IsMouseMoving)
+                            if (!window.IsMouseMoving && !window.IsFullscreen)
                             {
                                 handle.DeferWindowPos(window, adjustedLoc);
                             }

--- a/src/workspacer/Workspace/WorkspaceManager.cs
+++ b/src/workspacer/Workspace/WorkspaceManager.cs
@@ -417,7 +417,8 @@ namespace workspacer
                         }
                     }
 
-                    if (type == WindowUpdateType.Move)
+                    // Only change the current window if we are actively moving it.
+                    if (type == WindowUpdateType.Move && window.IsMouseMoving)
                     {
                         TrySwapWindowToMouse(window);
                     }


### PR DESCRIPTION
- Disabled permanent border on moving a window for performance reasons.
- Force layout on movement of window which helps with apps that move into last location (ex firefox and notepad++)
- Disable layout on workspaces with full-screen window.