### PR TITLE
Add behavior to spawn windows in the master slot (top of the list)

### DIFF
--- a/src/workspacer.Shared/IConfigContext.cs
+++ b/src/workspacer.Shared/IConfigContext.cs
@@ -23,8 +23,12 @@ namespace workspacer
 
         IMonitorContainer MonitorContainer { get; set; }
         bool CanMinimizeWindows { get; set; }
-        bool NewWindowAsMaster { get; set; }
-        
+        WindowOrder NewWindowOrder { get; set; }
+        public enum WindowOrder
+        {
+            NewWindowsLast, // default
+            NewWindowsFirst
+        }
         string ConfigDirectory { get; }
 
         /// <summary>

--- a/src/workspacer.Shared/IConfigContext.cs
+++ b/src/workspacer.Shared/IConfigContext.cs
@@ -24,11 +24,7 @@ namespace workspacer
         IMonitorContainer MonitorContainer { get; set; }
         bool CanMinimizeWindows { get; set; }
         WindowOrder NewWindowOrder { get; set; }
-        public enum WindowOrder
-        {
-            NewWindowsLast, // default
-            NewWindowsFirst
-        }
+
         string ConfigDirectory { get; }
 
         /// <summary>
@@ -94,5 +90,11 @@ namespace workspacer
         /// restart workspacer
         /// </summary>
         void Restart();
+    }
+
+    public enum WindowOrder
+    {
+        NewWindowsLast, // default
+        NewWindowsFirst
     }
 }

--- a/src/workspacer.Shared/IConfigContext.cs
+++ b/src/workspacer.Shared/IConfigContext.cs
@@ -23,6 +23,7 @@ namespace workspacer
 
         IMonitorContainer MonitorContainer { get; set; }
         bool CanMinimizeWindows { get; set; }
+        bool NewWindowAsMaster { get; set; }
         
         string ConfigDirectory { get; }
 

--- a/src/workspacer.Shared/Workspace/Workspace.cs
+++ b/src/workspacer.Shared/Workspace/Workspace.cs
@@ -73,7 +73,7 @@ namespace workspacer
                     _lastFocused = window;
                 }
 
-                if (_context.NewWindowAsMaster)
+                if (_context.NewWindowOrder == IConfigContext.WindowOrder.NewWindowsFirst)
                 {
                     _windows.Insert(0, window);
                 }

--- a/src/workspacer.Shared/Workspace/Workspace.cs
+++ b/src/workspacer.Shared/Workspace/Workspace.cs
@@ -73,7 +73,7 @@ namespace workspacer
                     _lastFocused = window;
                 }
 
-                if (_context.NewWindowOrder == IConfigContext.WindowOrder.NewWindowsFirst)
+                if (_context.NewWindowOrder == WindowOrder.NewWindowsFirst)
                 {
                     _windows.Insert(0, window);
                 }

--- a/src/workspacer.Shared/Workspace/Workspace.cs
+++ b/src/workspacer.Shared/Workspace/Workspace.cs
@@ -73,7 +73,15 @@ namespace workspacer
                     _lastFocused = window;
                 }
 
-                _windows.Add(window);
+                if (_context.NewWindowAsMaster)
+                {
+                    _windows.Insert(0, window);
+                }
+                else
+                {
+                    _windows.Add(window);
+                }
+                
 
                 if (layout)
                     DoLayout();

--- a/src/workspacer/ConfigContext.cs
+++ b/src/workspacer/ConfigContext.cs
@@ -30,7 +30,7 @@ namespace workspacer
         public IMonitorContainer MonitorContainer { get; set; }
 
         public bool CanMinimizeWindows { get; set; } = false;
-        public IConfigContext.WindowOrder NewWindowOrder { get; set; } = IConfigContext.WindowOrder.NewWindowsLast;
+        public WindowOrder NewWindowOrder { get; set; } = WindowOrder.NewWindowsLast;
 
         public string ConfigDirectory => FileHelper.GetConfigDirectory();
 

--- a/src/workspacer/ConfigContext.cs
+++ b/src/workspacer/ConfigContext.cs
@@ -30,8 +30,8 @@ namespace workspacer
         public IMonitorContainer MonitorContainer { get; set; }
 
         public bool CanMinimizeWindows { get; set; } = false;
-        public bool NewWindowAsMaster { get; set; } = false;    
-        
+        public IConfigContext.WindowOrder NewWindowOrder { get; set; } = IConfigContext.WindowOrder.NewWindowsLast;
+
         public string ConfigDirectory => FileHelper.GetConfigDirectory();
 
         private System.Timers.Timer _timer;

--- a/src/workspacer/ConfigContext.cs
+++ b/src/workspacer/ConfigContext.cs
@@ -30,6 +30,7 @@ namespace workspacer
         public IMonitorContainer MonitorContainer { get; set; }
 
         public bool CanMinimizeWindows { get; set; } = false;
+        public bool NewWindowAsMaster { get; set; } = false;    
         
         public string ConfigDirectory => FileHelper.GetConfigDirectory();
 


### PR DESCRIPTION
Pretty self explanatory. For my needs, I almost always want to focus on the new windows I open, so I added the behavior to the configuration context for spawning windows as the first items in the linked list (master slot), instead of the current behavior that always spawns them on the bottom of the list. 

I am very bad at naming variables, so I accept suggestions on a better name for this config variable.

Spawning Explorer with ``context.NewWindowAsMaster <- false`` (old behavior)
![image](https://user-images.githubusercontent.com/33640338/194381508-3e18567e-673a-495f-9994-0e88a226e6a9.png)
Spawning Explorer with ``context.NewWindowAsMaster <- true`` (new behavior option)
![image](https://user-images.githubusercontent.com/33640338/194381989-f1d2e030-318c-4104-a780-63a2d01b2ca3.png)


